### PR TITLE
chore: pin rubygems credentials action to v2.0.0

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -29,7 +29,7 @@ jobs:
           bundle install
 
       - name: Configure RubyGems credentials (OIDC trusted publishing)
-        uses: rubygems/configure-rubygems-credentials@v1
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
 
       - name: Publish to RubyGems.org
         run: |

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -29,7 +29,7 @@ jobs:
           bundle install
 
       - name: Configure RubyGems credentials (OIDC trusted publishing)
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
+        uses: rubygems/configure-rubygems-credentials@v2.0.0
 
       - name: Publish to RubyGems.org
         run: |


### PR DESCRIPTION
## What

Pin `rubygems/configure-rubygems-credentials` to `@v2.0.0` in `publish-gem.yml`.

## Why

The `Publish Gem` workflow for the 1.334.0 release failed at setup:

```
##[error]Unable to resolve action `rubygems/configure-rubygems-credentials@v1`, unable to find version `v1`
```

The action only ships **immutable** tags (`v1.0.0`, `v2.0.0`) — there is no moving `v1` major tag — so `@v1` can't resolve, and gem 1.334.0 never published (rubygems.org is stuck at 1.333.1). Pinning to `@v2.0.0` (current release; v1.0.0 is from 2023). Our usage is a bare `uses:` with no inputs, so the major bump carries no breaking change for us.

## Release

Merge with a `Release-As: 1.334.1` footer so release-please cuts a patch that republishes via the fixed workflow. 1.334.1 supersedes the never-published 1.334.0.

Generator overlay fixed in bnk-dev/sdk-generator#13 to prevent regression on the next sync.